### PR TITLE
[Feat] 사용자 실시간 스트림을 불러오는 useMediaStream, 이를 렌더링하는 VideoStream 컴포넌트 구현

### DIFF
--- a/packages/frontend/src/components/gamePage/stream/VideoStream.tsx
+++ b/packages/frontend/src/components/gamePage/stream/VideoStream.tsx
@@ -1,0 +1,19 @@
+import React, { useRef, useEffect } from 'react';
+import { useMediaStream } from '@/hooks/UseMediaStream';
+
+export default function VideoStream() {
+    const { mediaStream, error } = UseMediaStream();
+    const videoRef = useRef<HTMLVideoElement>(null);
+
+    useEffect(() => {
+        if (videoRef.current && mediaStream) {
+            videoRef.current.srcObject = mediaStream;
+        }
+    }, [mediaStream]);
+
+    return (
+        <div>
+            {error ? <p>{error}</p> : <video ref={videoRef} autoPlay />}
+        </div>
+    );
+}

--- a/packages/frontend/src/hooks/useMediaStream.ts
+++ b/packages/frontend/src/hooks/useMediaStream.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+export default function useMediaStream() {
+    const [mediaStream, setMediaStream] = useState<MediaStream | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        async function getMediaStream() {
+            try {
+                const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+                setMediaStream(stream);
+            } catch (err) {
+                setError("사용자의 카메라와 마이크에 접근하지 못했습니다.");
+            }
+        }
+
+        getMediaStream();
+    }, []);
+
+    return { mediaStream, error };
+}


### PR DESCRIPTION
### issue https://github.com/orgs/boostcampwm-2024/projects/67/views/1?pane=issue&itemId=85323360&issue=boostcampwm-2024%7Cweb23-Pinoco%7C25

## 개요

사용자 실시간 스트림을 불러오는 `useMediaStream`과 이를 렌더링하는 `VideoStream` 컴포넌트를 구현했습니다.


## 작업 내용

### useMediaStream.ts

- `useMediaStream` 함수는 사용자로부터 카메라와 마이크 접근 권한을 요청하고, 이를 통해 오디오와 비디오 스트림을 제공하는 커스텀 훅입니다.

```ts
export default function useMediaStream() {
    const [mediaStream, setMediaStream] = useState<MediaStream | null>(null);
    const [error, setError] = useState<string | null>(null);
```

- `mediaStream` 은 `MediaStream` 객체, 그러니까 카메라와 마이크 스트림을 저장합니다.

```ts
    useEffect(() => {
        async function getMediaStream() {
            try {
                const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
                setMediaStream(stream);
            } catch (err) {
                setError("사용자의 카메라와 마이크에 접근하지 못했습니다.");
            }
        }

        getMediaStream();

    }, []);

```

- `useEffect`를 통해 컴포넌트가 처음 렌더링될 때 `getMediaStream` 함수를 호출하도록 설정했습니다. 이미 권한을 승인받았다면 매번 컴포넌트가 렌더링될 때마다 새로 요청할 필요가 없기도 하고, `navigator.mediaDevices.getUserMedia`를 중복 호출하는 것을 방지하고자 했습니다.

- `navigator.mediaDevices.getUserMedia`는 브라우저의 내장 API로, `{ video: true, audio: true }`와 같은 옵션을 받아 사용자의 카메라와 마이크 접근을 요청합니다. 여기서는 두 장치 모두에 접근하도록 옵션을 부여했습니다.

- `getUserMedia`는 `Promise` 객체를 반환합니다. 권한 요청이 승인되면 `resolve`되어 사용 가능한 `MediaStream` 객체를 제공합니다.

- 이 `MediaStream` 객체는 video나 audio 요소의 `srcObject` 속성에 할당하여 실시간 스트림을 화면에 표시할 수 있습니다.

```ts
    return { mediaStream, error };
}
```

- 최종으로 `mediaStream`과 error를 객체로 반환하여, 이 훅을 사용하는 컴포넌트에서 스트림 데이터를 쉽게 가져다 사용할 수 있도록 했습니다.

### VideoStream.tsx

- `VideoStream` 컴포넌트는 `useMediaStream` 훅을 사용해 사용자 미디어를 가져와 `video` 요소에 실시간 스트림을 렌더링합니다.

```ts
export default function VideoStream() {
    const { mediaStream, error } = useMediaStream();
    const videoRef = useRef<HTMLVideoElement>(null);
```

- 우선 `useMediaStream` 훅을 호출하여, `mediaStream`과 error 값을 가져옵니다.

- `mediaStream`에는 사용자의 카메라와 마이크를 통해 수집된 `MediaStream` 객체가 저장되며, 사용자 권한이 없을 때는 null로 설정했습니다.

- `videoRef`는 `HTMLVideoElement`를 참조하는 `useRef` 훅으로, `video` 요소에 접근할 수 있도록 합니다.

```ts
    useEffect(() => {
        if (videoRef.current && mediaStream) {
            videoRef.current.srcObject = mediaStream;
        }
    }, [mediaStream]);
```

- `useEffect`는 `mediaStream`이 업데이트될 때마다 실행됩니다.

- `videoRef.current`가 존재하고 `mediaStream`이 준비된 경우, `videoRef.current.srcObject`를 `mediaStream`으로 설정하여 `video` 요소에 스트림을 연결합니다.

- `srcObject`에 `mediaStream`을 할당하면, 해당 `video` 요소에서 실시간 비디오 스트림을 재생할 수 있습니다.

```ts
    return (
        <div>
            {error ? <p>{error}</p> : <video ref={videoRef} autoPlay />}
        </div>
    );
}
```

- error가 없고 `mediaStream`이 성공적으로 연결되었으면 `video` 요소를 화면에 렌더링합니다.

- `ref={videoRef}`로 `video` 요소에 `videoRef`를 연결하여 DOM 요소에 접근할 수 있게 해줬습니다.

- `autoPlay` 속성은 사용자가 직접 재생 버튼을 누를 필요 없이 스트림이 자동 재생되도록 해주는 옵션입니다.

### 게임 화면에서의 활용 방법

- 그래서 이걸 우째 쓰느냐 ..

- `VideoStream` 컴포넌트 4-6개를 인스턴스화하여 배열 형태로 생성하고, 각 컴포넌트가 다른 사용자와 연결된 MediaStream 객체를 전달받도록 해주는 방식으로 사용하면 될 것 같습니다.

## 스크린샷

![스크린샷 2024-11-06 오후 4 29 28](https://github.com/user-attachments/assets/1f401e99-0486-4c3f-ac92-9ebf087e8d10)

- 테스트를 위해 App.tsx에 `VideoStream` 컴포넌트를 추가하여 정상 작동하는 것을 확인했습니다.


## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
