### PR TITLE
[Fix] 수정된 api 명세에 따른 채팅 로직 수정

### DIFF
--- a/packages/frontend/src/components/gamePage/rightSection/ChatSection.tsx
+++ b/packages/frontend/src/components/gamePage/rightSection/ChatSection.tsx
@@ -6,19 +6,18 @@ import { useChatStore } from '@/states/store/chatStore';
 
 export default function ChatSection() {
   const { gsid } = useParams();
-  const userId = useAuthStore((state) => state.userId);
+  const { userId } = useAuthStore();
   const { messages } = useChatStore();
   const { sendMessage } = useChatSocket(gsid!, userId!);
   const [chat, setChat] = useState('');
 
   const handleSend = () => {
-    if (chat.trim()) {
-      sendMessage(chat);
-      setChat('');
-    }
+    if (!chat.trim()) return;
+    sendMessage(chat);
+    setChat('');
   };
 
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       handleSend();
     }
@@ -38,7 +37,7 @@ export default function ChatSection() {
         placeholder="채팅을 입력해주세요..."
         value={chat}
         onChange={(e) => setChat(e.target.value)}
-        onKeyPress={handleKeyPress}
+        onKeyDown={handleKeyDown}
       />
     </div>
   );

--- a/packages/frontend/src/components/gamePage/rightSection/ChatSection.tsx
+++ b/packages/frontend/src/components/gamePage/rightSection/ChatSection.tsx
@@ -7,13 +7,13 @@ import { useChatStore } from '@/states/store/chatStore';
 export default function ChatSection() {
   const { gsid } = useParams();
   const { userId } = useAuthStore();
-  const { messages } = useChatStore();
-  const { sendMessage } = useChatSocket(gsid!, userId!);
-  const [chat, setChat] = useState('');
+  const { chatHistory } = useChatStore();
+  const { sendChatEntry } = useChatSocket(gsid!, userId!);
+  const [chatInput, setChat] = useState('');
 
   const handleSend = () => {
-    if (!chat.trim()) return;
-    sendMessage(chat);
+    if (!chatInput.trim()) return;
+    sendChatEntry(chatInput);
     setChat('');
   };
 
@@ -26,16 +26,16 @@ export default function ChatSection() {
   return (
     <div className="flex flex-col flex-grow p-4 bg-black rounded-lg opacity-80 text-white-default">
       <div className="h-56 mt-2 space-y-2 overflow-y-auto grow">
-        {messages.map((msg, index) => (
+        {chatHistory.map((entry, index) => (
           <div key={index} className="text-sm">
-            <span className="font-semibold">{msg.userId}</span>: {msg.message}
+            <span className="font-semibold">{entry.userId}</span>: {entry.message}
           </div>
         ))}
       </div>
       <input
         className="w-full p-2 mt-4 bg-gray-600 rounded-lg outline-none"
         placeholder="채팅을 입력해주세요..."
-        value={chat}
+        value={chatInput}
         onChange={(e) => setChat(e.target.value)}
         onKeyDown={handleKeyDown}
       />

--- a/packages/frontend/src/hooks/useChatSocket.ts
+++ b/packages/frontend/src/hooks/useChatSocket.ts
@@ -2,21 +2,20 @@ import { useEffect } from 'react';
 import { useChatStore } from '@/states/store/chatStore';
 import { useSocketStore } from '@/states/store/socketStore';
 
-interface IChatMessage {
+interface IChatEntry {
   userId: string;
   message: string;
 }
 
 export const useChatSocket = (gsid: string, userId: string) => {
-  const addMessage = useChatStore((state) => state.addMessage);
+  const addChatEntry = useChatStore((state) => state.addChatEntry);
   const socket = useSocketStore((state) => state.socket);
 
   useEffect(() => {
     if (!socket) return;
 
-    // 새로운 메시지 수신
-    socket.on('receive_message', (data: IChatMessage) => {
-      addMessage(data);
+    socket.on('receive_message', (data: IChatEntry) => {
+      addChatEntry(data);
     });
 
     return () => {
@@ -24,12 +23,12 @@ export const useChatSocket = (gsid: string, userId: string) => {
     };
   }, [gsid, socket]);
 
-  const sendMessage = (message: string) => {
+  const sendChatEntry = (message: string) => {
     if (!socket || !message.trim()) return;
-    const newMessage = { userId, message };
-    addMessage(newMessage);
+    const newEntry = { userId, message };
+    addChatEntry(newEntry);
     socket.emit('send_message', { gsid, message });
   };
 
-  return { sendMessage };
+  return { sendChatEntry };
 };

--- a/packages/frontend/src/hooks/useChatSocket.ts
+++ b/packages/frontend/src/hooks/useChatSocket.ts
@@ -9,16 +9,10 @@ interface IChatMessage {
 
 export const useChatSocket = (gsid: string, userId: string) => {
   const addMessage = useChatStore((state) => state.addMessage);
-  const setMessages = useChatStore((state) => state.setMessages);
   const socket = useSocketStore((state) => state.socket);
 
   useEffect(() => {
     if (!socket) return;
-
-    // 기존 채팅 기록 수신
-    socket.on('join_room_success', (data) => {
-      setMessages(data.chatHistory);
-    });
 
     // 새로운 메시지 수신
     socket.on('receive_message', (data: IChatMessage) => {
@@ -26,7 +20,6 @@ export const useChatSocket = (gsid: string, userId: string) => {
     });
 
     return () => {
-      socket.off('join_room_success');
       socket.off('receive_message');
     };
   }, [gsid, socket]);
@@ -35,7 +28,7 @@ export const useChatSocket = (gsid: string, userId: string) => {
     if (!socket || !message.trim()) return;
     const newMessage = { userId, message };
     addMessage(newMessage);
-    socket.emit('send_message', { gsid, userId, message });
+    socket.emit('send_message', { gsid, message });
   };
 
   return { sendMessage };

--- a/packages/frontend/src/states/store/chatStore.ts
+++ b/packages/frontend/src/states/store/chatStore.ts
@@ -1,18 +1,18 @@
 import { create } from 'zustand';
 
-interface IChatMessage {
+interface IChatEntry {
   userId: string;
   message: string;
 }
 
 interface IChatState {
-  messages: IChatMessage[];
-  addMessage: (message: IChatMessage) => void;
-  setMessages: (messages: IChatMessage[]) => void;
+  chatHistory: IChatEntry[];
+  addChatEntry: (entry: IChatEntry) => void;
+  setChatHistory: (history: IChatEntry[]) => void;
 }
 
 export const useChatStore = create<IChatState>((set) => ({
-  messages: [],
-  addMessage: (message) => set((state) => ({ messages: [...state.messages, message] })),
-  setMessages: (messages) => set({ messages }),
+  chatHistory: [],
+  addChatEntry: (entry) => set((state) => ({ chatHistory: [...state.chatHistory, entry] })),
+  setChatHistory: (history) => set({ chatHistory: history }),
 }));


### PR DESCRIPTION
## 개요

Resolves: #99 

## PR 유형

어떤 변경 사항이 있나요?
- [x] 로직 수정

## 작업 내용

채팅을 보내는 경우 `send_message` 타입으로 { gsid: string, message: string } 를 보내도록 수정.
다른 사용자에 의해 채팅이 추가되는 경우 `receive_message`를 통해 다른 사용자의 메세지를 받아 현재 메세지 목록에 추가하도록 수정.

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
