### PR TITLE
[Feat] 방 생성, 참가 로직 게임서버와 연동

### DIFF
--- a/packages/frontend/src/components/layout/BackgroundImage.tsx
+++ b/packages/frontend/src/components/layout/BackgroundImage.tsx
@@ -1,4 +1,4 @@
-import Background from '@/assets/images/BackgroundImage.svg?url';
+import Background from '@/assets/images/BackgroundImage.svg';
 
 interface IBackgroundImageProps {
   gradientClass: string;

--- a/packages/frontend/src/components/layout/BackgroundImage.tsx
+++ b/packages/frontend/src/components/layout/BackgroundImage.tsx
@@ -1,4 +1,4 @@
-import Background from '@/assets/images/BackgroundImage.svg';
+import Background from '@/assets/images/BackgroundImage.svg?url';
 
 interface IBackgroundImageProps {
   gradientClass: string;

--- a/packages/frontend/src/components/layout/BackgroundImage.tsx
+++ b/packages/frontend/src/components/layout/BackgroundImage.tsx
@@ -4,7 +4,7 @@ interface IBackgroundImageProps {
   gradientClass: string;
 }
 
-export default function BackgroundImage({ gradientClass }: BackgroundImageProps) {
+export default function BackgroundImage({ gradientClass }: IBackgroundImageProps) {
   return (
     <div
       className="fixed inset-0 w-full h-full bg-center bg-cover -z-10"

--- a/packages/frontend/src/components/layout/BackgroundImage.tsx
+++ b/packages/frontend/src/components/layout/BackgroundImage.tsx
@@ -1,4 +1,4 @@
-import Background from '@/assets/images/BackgroundImage.svg';
+import Background from '@/assets/images/BackGroundImage.svg';
 
 interface IBackgroundImageProps {
   gradientClass: string;

--- a/packages/frontend/src/components/lobbyPage/GameEntryModal.tsx
+++ b/packages/frontend/src/components/lobbyPage/GameEntryModal.tsx
@@ -1,0 +1,65 @@
+import ReactDOM from 'react-dom';
+import { useState } from 'react';
+
+interface IGameEntryModalProps {
+  title: string;
+  subtitle?: string;
+  textForm?: string;
+  onConfirm: (gsid: string) => void;
+  onClose: () => void;
+}
+
+export default function GameEntryModal({
+  title,
+  subtitle,
+  textForm,
+  onConfirm,
+  onClose,
+}: IGameEntryModalProps) {
+  const [gameCode, setGameCode] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleConfirm = () => {
+    if (gameCode.trim()) {
+      setErrorMessage('');
+      onConfirm(gameCode);
+    } else {
+      setErrorMessage('게임 코드를 입력해주세요.');
+    }
+  };
+
+  const modalContent = (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="max-w-lg p-8 bg-white shadow-lg rounded-2xl w-96">
+        <h2 className="mb-4 text-xl font-semibold text-center text-gray-900">{title}</h2>
+        {subtitle && <p className="mb-4 text-left text-gray-800">{subtitle}</p>}
+        {textForm && (
+          <input
+            type="text"
+            placeholder={textForm}
+            value={gameCode}
+            onChange={(e) => setGameCode(e.target.value)}
+            className="w-full py-2 mb-2 text-left text-gray-700 placeholder-gray-500 border-b-2 focus:outline-none"
+          />
+        )}
+        {errorMessage && <p className="mb-4 text-sm text-red-500">{errorMessage}</p>}
+        <div className="flex justify-center gap-4 mt-4">
+          <button
+            onClick={onClose}
+            className="w-32 py-2 text-black border border-black rounded-lg hover:bg-gray-100"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleConfirm}
+            className="w-32 py-2 bg-black rounded-lg text-white hover:bg-gray-800"
+          >
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  return ReactDOM.createPortal(modalContent, document.getElementById('portal-root') as HTMLElement);
+}

--- a/packages/frontend/src/components/lobbyPage/RoomJoinButton.tsx
+++ b/packages/frontend/src/components/lobbyPage/RoomJoinButton.tsx
@@ -1,11 +1,12 @@
 import useModal from '@/hooks/useModal';
-import Modal from '@/components/common/Modal';
+import GameEntryModal from '@/components/lobbyPage/GameEntryModal';
 import Button from '@/components/common/Button';
 import useJoinRoom from '@/hooks/useJoinRoom';
 
 export default function RoomJoinButton() {
   const { isOpen, openModal, closeModal } = useModal();
   const { handleJoinRoom } = useJoinRoom();
+
   return (
     <>
       <Button
@@ -14,10 +15,10 @@ export default function RoomJoinButton() {
         buttonText="게임 참가하기"
       />
       {isOpen && (
-        <Modal
+        <GameEntryModal
           title="게임 참가하기"
-          subtitle="게임코드 입력"
-          textForm="코드 입력"
+          subtitle="게임코드를 입력해주세요"
+          textForm="게임 코드 입력"
           onClose={closeModal}
           onConfirm={handleJoinRoom}
         />

--- a/packages/frontend/src/hooks/useCreateRoom.ts
+++ b/packages/frontend/src/hooks/useCreateRoom.ts
@@ -1,8 +1,3 @@
-import { useNavigate } from 'react-router-dom';
-import { useAuthStore } from '@/states/store/authStore';
-import { useRoomStore } from '@/states/store/roomStore';
-import { useSocketStore } from '@/states/store/socketStore';
-
 export default function useCreateRoom() {
   const navigate = useNavigate();
   const userId = useAuthStore((state) => state.userId);
@@ -13,13 +8,19 @@ export default function useCreateRoom() {
     if (!userId || !socket) return;
 
     socket.emit('create_room', { usid: userId });
+
     socket.on('create_room_success', (data) => {
       setRoomData(data.gsid, data.isHost);
       navigate(`/game/${data.gsid}`);
     });
 
+    socket.on('error', (data) => {
+      alert(`방 생성에 실패했습니다: ${data.errorMessage}`);
+    });
+
     return () => {
       socket.off('create_room_success');
+      socket.off('error');
     };
   }
 

--- a/packages/frontend/src/hooks/useCreateRoom.ts
+++ b/packages/frontend/src/hooks/useCreateRoom.ts
@@ -1,3 +1,8 @@
+import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/states/store/authStore';
+import { useRoomStore } from '@/states/store/roomStore';
+import { useSocketStore } from '@/states/store/socketStore';
+
 export default function useCreateRoom() {
   const navigate = useNavigate();
   const userId = useAuthStore((state) => state.userId);
@@ -9,13 +14,13 @@ export default function useCreateRoom() {
 
     socket.emit('create_room', { usid: userId });
 
-    socket.on('create_room_success', (data) => {
+    socket.on('create_room_success', (data: { gsid: string; isHost: boolean }) => {
       setRoomData(data.gsid, data.isHost);
       navigate(`/game/${data.gsid}`);
     });
 
-    socket.on('error', (data) => {
-      alert(`방 생성에 실패했습니다: ${data.errorMessage}`);
+    socket.on('error', (data: { errorMessage: string }) => {
+      alert(data.errorMessage);
     });
 
     return () => {

--- a/packages/frontend/src/hooks/useJoinRoom.ts
+++ b/packages/frontend/src/hooks/useJoinRoom.ts
@@ -1,3 +1,8 @@
+import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/states/store/authStore';
+import { useRoomStore } from '@/states/store/roomStore';
+import { useSocketStore } from '@/states/store/socketStore';
+
 export default function useJoinRoom() {
   const navigate = useNavigate();
   const userId = useAuthStore((state) => state.userId);
@@ -9,12 +14,12 @@ export default function useJoinRoom() {
 
     socket.emit('join_room', { usid: userId, gsid });
 
-    socket.on('join_room_success', (data) => {
+    socket.on('join_room_success', (data: { gsid: string; isHost: boolean }) => {
       setRoomData(data.gsid, data.isHost);
       navigate(`/game/${data.gsid}`);
     });
 
-    socket.on('error', (data) => {
+    socket.on('error', (data: { errorMessage: string }) => {
       alert(`방 참가에 실패했습니다: ${data.errorMessage}`);
     });
 

--- a/packages/frontend/src/hooks/useJoinRoom.ts
+++ b/packages/frontend/src/hooks/useJoinRoom.ts
@@ -1,8 +1,3 @@
-import { useNavigate } from 'react-router-dom';
-import { useAuthStore } from '@/states/store/authStore';
-import { useRoomStore } from '@/states/store/roomStore';
-import { useSocketStore } from '@/states/store/socketStore';
-
 export default function useJoinRoom() {
   const navigate = useNavigate();
   const userId = useAuthStore((state) => state.userId);
@@ -19,13 +14,13 @@ export default function useJoinRoom() {
       navigate(`/game/${data.gsid}`);
     });
 
-    socket.on('join_room_fail', (data) => {
+    socket.on('error', (data) => {
       alert(`방 참가에 실패했습니다: ${data.errorMessage}`);
     });
 
     return () => {
       socket.off('join_room_success');
-      socket.off('join_room_fail');
+      socket.off('error');
     };
   }
 

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -5,5 +5,23 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths(), svgrPlugin()],
-  assetsInclude: ['**/*.svg'],
+  build: {
+    rollupOptions: {
+      plugins: [
+        {
+          name: 'resolve-svg',
+          resolveId(source) {
+            if (source.endsWith('.svg')) return source;
+            return null;
+          },
+          load(id) {
+            if (id.endsWith('.svg')) {
+              return `export default ${JSON.stringify(id)}`;
+            }
+            return null;
+          },
+        },
+      ],
+    },
+  },
 });

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -5,9 +5,5 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths(), svgrPlugin()],
-  build: {
-    rollupOptions: {
-      assetsInclude: ['**/*.svg'],
-    },
-  },
+  assetsInclude: ['**/*.svg'],
 });

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -5,4 +5,9 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths(), svgrPlugin()],
+  build: {
+    rollupOptions: {
+      assetsInclude: ['**/*.svg'],
+    },
+  },
 });


### PR DESCRIPTION
## 개요

Resolves: #108 

## 작업 내용

- 게임 참가 코드 입력을 위한 GameEntryModal 컴포넌트를 추가하고 기존 모달을 대체했습니다.

- 기존에 단순 네비게이트만 이루어지던 게임 생성 로직에 소켓 통신을 추가했습니다.

- 업데이트된 에러 로직 명세를 적용했습니다.

- CI 통과를 위해 추가적인 CI 코드 수정도 이루어졌습니다.

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
