### PR TITLE
[Feat] receive_vote_result에 따라 투표 결과를 보여주고, 다음 페이즈로 이동하는 로직 구현

### DIFF
--- a/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
@@ -175,7 +175,7 @@ export default function MainDisplay() {
           </div>
         )}
 
-        {gamePhase === GAME_PHASE.VOTING && (deadPerson ? renderVoteResult() : renderVotingUI())}
+        {gamePhase === GAME_PHASE.VOTING && (deadPerson ? renderVoteResultUI() : renderVotingUI())}
 
         {gamePhase === GAME_PHASE.GUESSING && (
           <div className="flex flex-col items-center justify-center h-full">

--- a/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
@@ -175,7 +175,7 @@ export default function MainDisplay() {
           </div>
         )}
 
-        {gamePhase === GAME_PHASE.VOTING && renderVotingUI()}
+        {gamePhase === GAME_PHASE.VOTING && (deadPerson ? renderVoteResult() : renderVotingUI())}
 
         {gamePhase === GAME_PHASE.GUESSING && (
           <div className="flex flex-col items-center justify-center h-full">
@@ -188,8 +188,6 @@ export default function MainDisplay() {
             )}
           </div>
         )}
-
-        {gamePhase === GAME_PHASE.VOTE_RESULT && renderVoteResultUI()}
 
         {gamePhase === GAME_PHASE.ENDING && renderEndingUI()}
 

--- a/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
@@ -27,7 +27,7 @@ export default function MainDisplay() {
 
   const { submitGuess } = useGuessing(isPinoco, setGamePhase);
 
-  const { voteResult, deadPerson } = useVoteResult(setRemainingPlayers);
+  const { voteResult, deadPerson } = useVoteResult(remainingPlayers, setRemainingPlayers);
 
   useEffect(() => {
     if (gameStartData) {

--- a/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
@@ -9,6 +9,7 @@ import GuessInput from './GuessInput';
 import { useGameSocket } from '@/hooks/useGameSocket';
 import useGuessing from '@/hooks/useGuessing';
 import useEnding from '@/hooks/useEnding';
+import useVoteResult from '@/hooks/useVoteResult';
 
 export default function MainDisplay() {
   const { isHost, isPinoco } = useRoomStore();
@@ -22,9 +23,17 @@ export default function MainDisplay() {
   const [isTimerActive, setIsTimerActive] = useState(true);
   const [isVoteSubmitted, setIsVoteSubmitted] = useState(false);
 
+  const [remainingPlayers, setRemainingPlayers] = useState(readyUsers.length);
+
   const { submitGuess } = useGuessing(isPinoco, setGamePhase);
 
-  // 게임 시작 시 카운트다운 및 단어 공개
+  const { voteResult, deadPerson } = useVoteResult(
+    setGamePhase,
+    remainingPlayers,
+    isPinoco,
+    setRemainingPlayers,
+  );
+
   useEffect(() => {
     if (gameStartData) {
       setGamePhase(GAME_PHASE.COUNTDOWN);
@@ -118,6 +127,24 @@ export default function MainDisplay() {
     );
   };
 
+  const renderVoteResultUI = () => (
+    <div className="flex flex-col items-center justify-center w-full h-full space-y-4">
+      <h2 className="text-2xl font-bold text-white-default">투표 결과</h2>
+      {deadPerson === 'none' ? (
+        <p className="text-xl text-white-default">동점입니다. 아무도 제거되지 않았습니다.</p>
+      ) : (
+        <p className="text-xl text-white-default">{deadPerson}님이 제거되었습니다.</p>
+      )}
+      <ul className="mt-4 space-y-2">
+        {Object.entries(voteResult).map(([userId, votes]) => (
+          <li key={userId} className="text-lg text-white-default">
+            {userId}: {votes}표
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+
   return (
     <div className="relative flex flex-col flex-grow w-full p-4 mt-4 rounded-lg bg-green-default/40">
       <div className="flex-grow">
@@ -161,6 +188,8 @@ export default function MainDisplay() {
             )}
           </div>
         )}
+
+        {gamePhase === GAME_PHASE.VOTE_RESULT && renderVoteResultUI()}
 
         {gamePhase === GAME_PHASE.ENDING && renderEndingUI()}
 

--- a/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
@@ -27,12 +27,7 @@ export default function MainDisplay() {
 
   const { submitGuess } = useGuessing(isPinoco, setGamePhase);
 
-  const { voteResult, deadPerson } = useVoteResult(
-    setGamePhase,
-    remainingPlayers,
-    isPinoco,
-    setRemainingPlayers,
-  );
+  const { voteResult, deadPerson } = useVoteResult(setRemainingPlayers);
 
   useEffect(() => {
     if (gameStartData) {
@@ -72,7 +67,7 @@ export default function MainDisplay() {
 
   const renderVotingUI = () => (
     <div className="flex flex-col items-center justify-center w-full h-full space-y-6">
-      <h2 className="text-2xl font-bold text-white-default">라이어를 지목해주세요!</h2>
+      <h2 className="text-2xl font-bold text-white-default">피노코를 지목해주세요!</h2>
       <div className="flex flex-col w-full max-w-md space-y-3">
         {readyUsers.map((userId: string) => (
           <button
@@ -92,7 +87,7 @@ export default function MainDisplay() {
       {isVoteSubmitted ? (
         <div className="flex flex-col items-center space-y-2">
           <p className="text-lg font-medium text-white-default">
-            {selectedVote}님을 라이어로 지목하였습니다
+            {selectedVote}님을 피노코로 지목하였습니다
           </p>
           <p className="text-sm text-white-default">잠시 후 결과가 공개됩니다</p>
         </div>

--- a/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
@@ -23,7 +23,7 @@ export default function MainDisplay() {
   const [isTimerActive, setIsTimerActive] = useState(true);
   const [isVoteSubmitted, setIsVoteSubmitted] = useState(false);
 
-  const [remainingPlayers, setRemainingPlayers] = useState(readyUsers.length);
+  const [remainingPlayers, setRemainingPlayers] = useState<number>(readyUsers.length);
 
   const { submitGuess } = useGuessing(isPinoco, setGamePhase);
 

--- a/packages/frontend/src/hooks/useVoteResult.ts
+++ b/packages/frontend/src/hooks/useVoteResult.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { useSocketStore } from '@/states/store/socketStore';
+import { GAME_PHASE, GamePhase } from '@/constants';
+
+interface IVoteResult {
+  voteResult: Record<string, number>;
+  deadPerson: string;
+}
+
+export default function useVoteResult(
+  setGamePhase: (phase: GamePhase) => void,
+  remainingPlayers: number,
+  isPinoco: boolean,
+  setRemainingPlayers: (value: number) => void,
+) {
+  const socket = useSocketStore((state) => state.socket);
+  const [voteResult, setVoteResult] = useState<Record<string, number>>({});
+  const [deadPerson, setDeadPerson] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!socket) return;
+
+    socket.on('receive_vote_result', (data: IVoteResult) => {
+      setVoteResult(data.voteResult);
+      setDeadPerson(data.deadPerson);
+
+      setTimeout(() => {
+        if (data.deadPerson === 'none') {
+          socket.emit('start_speaking');
+          setGamePhase(GAME_PHASE.SPEAKING);
+        } else if (data.deadPerson === 'pinoco') {
+          if (isPinoco) {
+            socket.emit('start_guessing');
+          }
+          setGamePhase(GAME_PHASE.GUESSING);
+        } else {
+          setRemainingPlayers((prev) => prev - 1);
+          if (remainingPlayers <= 3) {
+            socket.emit('start_ending');
+            setGamePhase(GAME_PHASE.ENDING);
+          } else {
+            socket.emit('start_speaking');
+            setGamePhase(GAME_PHASE.SPEAKING);
+          }
+        }
+      }, 5000);
+    });
+
+    return () => {
+      socket.off('receive_vote_result');
+    };
+  }, [socket, setGamePhase, remainingPlayers, isPinoco, setRemainingPlayers]);
+
+  return {
+    voteResult,
+    deadPerson,
+  };
+}

--- a/packages/frontend/src/hooks/useVoteResult.ts
+++ b/packages/frontend/src/hooks/useVoteResult.ts
@@ -19,7 +19,8 @@ export default function useVoteResult(setRemainingPlayers: (value: number) => vo
       setDeadPerson(data.deadPerson);
 
       if (data.deadPerson !== 'none' && data.deadPerson) {
-        setRemainingPlayers((currentPlayers: number) => currentPlayers - 1);
+        const updatedPlayers = remainingPlayers - 1;
+        setRemainingPlayers(updatedPlayers);
       }
     });
 

--- a/packages/frontend/src/hooks/useVoteResult.ts
+++ b/packages/frontend/src/hooks/useVoteResult.ts
@@ -6,7 +6,10 @@ interface IVoteResult {
   deadPerson: string;
 }
 
-export default function useVoteResult(setRemainingPlayers: (value: number) => void) {
+export default function useVoteResult(
+  remainingPlayers: number,
+  setRemainingPlayers: (value: number) => void,
+) {
   const socket = useSocketStore((state) => state.socket);
   const [voteResult, setVoteResult] = useState<Record<string, number>>({});
   const [deadPerson, setDeadPerson] = useState<string | null>(null);
@@ -19,15 +22,14 @@ export default function useVoteResult(setRemainingPlayers: (value: number) => vo
       setDeadPerson(data.deadPerson);
 
       if (data.deadPerson !== 'none' && data.deadPerson) {
-        const updatedPlayers = remainingPlayers - 1;
-        setRemainingPlayers(updatedPlayers);
+        setRemainingPlayers(remainingPlayers - 1);
       }
     });
 
     return () => {
       socket.off('receive_vote_result');
     };
-  }, [socket, setRemainingPlayers]);
+  }, [socket, remainingPlayers, setRemainingPlayers]);
 
   return { voteResult, deadPerson };
 }

--- a/packages/frontend/src/hooks/useVoteResult.ts
+++ b/packages/frontend/src/hooks/useVoteResult.ts
@@ -16,7 +16,6 @@ export default function useVoteResult(
   const socket = useSocketStore((state) => state.socket);
   const [voteResult, setVoteResult] = useState<Record<string, number>>({});
   const [deadPerson, setDeadPerson] = useState<string | null>(null);
-
   useEffect(() => {
     if (!socket) return;
 
@@ -32,14 +31,17 @@ export default function useVoteResult(
           if (isPinoco) socket.emit('start_guessing');
           setGamePhase(GAME_PHASE.GUESSING);
         } else {
-          setRemainingPlayers((prev: number) => prev - 1);
-          if (remainingPlayers <= 2) {
-            socket.emit('start_ending');
-            setGamePhase(GAME_PHASE.ENDING);
-          } else {
-            socket.emit('start_speaking');
-            setGamePhase(GAME_PHASE.SPEAKING);
-          }
+          setRemainingPlayers((prev: number) => {
+            const updatedPlayers = prev - 1;
+            if (updatedPlayers <= 2) {
+              socket.emit('start_ending');
+              setGamePhase(GAME_PHASE.ENDING);
+            } else {
+              socket.emit('start_speaking');
+              setGamePhase(GAME_PHASE.SPEAKING);
+            }
+            return updatedPlayers;
+          });
         }
       }, 5000);
     });
@@ -47,7 +49,7 @@ export default function useVoteResult(
     return () => {
       socket.off('receive_vote_result');
     };
-  }, [socket, setGamePhase, remainingPlayers, isPinoco, setRemainingPlayers]);
+  }, [socket, setGamePhase, isPinoco, setRemainingPlayers]);
 
   return { voteResult, deadPerson };
 }

--- a/packages/frontend/src/hooks/useVoteResult.ts
+++ b/packages/frontend/src/hooks/useVoteResult.ts
@@ -19,7 +19,7 @@ export default function useVoteResult(setRemainingPlayers: (value: number) => vo
       setDeadPerson(data.deadPerson);
 
       if (data.deadPerson !== 'none' && data.deadPerson) {
-        setRemainingPlayers((currentPlayers) => currentPlayers - 1);
+        setRemainingPlayers((currentPlayers: number) => currentPlayers - 1);
       }
     });
 

--- a/packages/frontend/src/hooks/useVoteResult.ts
+++ b/packages/frontend/src/hooks/useVoteResult.ts
@@ -19,7 +19,7 @@ export default function useVoteResult(setRemainingPlayers: (value: number) => vo
       setDeadPerson(data.deadPerson);
 
       if (data.deadPerson !== 'none' && data.deadPerson) {
-        setRemainingPlayers((prev) => prev - 1);
+        setRemainingPlayers((prev: number) => prev - 1);
       }
     });
 

--- a/packages/frontend/src/hooks/useVoteResult.ts
+++ b/packages/frontend/src/hooks/useVoteResult.ts
@@ -16,6 +16,7 @@ export default function useVoteResult(
   const socket = useSocketStore((state) => state.socket);
   const [voteResult, setVoteResult] = useState<Record<string, number>>({});
   const [deadPerson, setDeadPerson] = useState<string | null>(null);
+
   useEffect(() => {
     if (!socket) return;
 

--- a/packages/frontend/src/hooks/useVoteResult.ts
+++ b/packages/frontend/src/hooks/useVoteResult.ts
@@ -19,7 +19,7 @@ export default function useVoteResult(setRemainingPlayers: (value: number) => vo
       setDeadPerson(data.deadPerson);
 
       if (data.deadPerson !== 'none' && data.deadPerson) {
-        setRemainingPlayers((prev: number) => prev - 1);
+        setRemainingPlayers((currentPlayers) => currentPlayers - 1);
       }
     });
 

--- a/packages/frontend/src/hooks/useVoteResult.ts
+++ b/packages/frontend/src/hooks/useVoteResult.ts
@@ -29,13 +29,11 @@ export default function useVoteResult(
           socket.emit('start_speaking');
           setGamePhase(GAME_PHASE.SPEAKING);
         } else if (data.deadPerson === 'pinoco') {
-          if (isPinoco) {
-            socket.emit('start_guessing');
-          }
+          if (isPinoco) socket.emit('start_guessing');
           setGamePhase(GAME_PHASE.GUESSING);
         } else {
-          setRemainingPlayers((prev) => prev - 1);
-          if (remainingPlayers <= 3) {
+          setRemainingPlayers((prev: number) => prev - 1);
+          if (remainingPlayers <= 2) {
             socket.emit('start_ending');
             setGamePhase(GAME_PHASE.ENDING);
           } else {
@@ -51,8 +49,5 @@ export default function useVoteResult(
     };
   }, [socket, setGamePhase, remainingPlayers, isPinoco, setRemainingPlayers]);
 
-  return {
-    voteResult,
-    deadPerson,
-  };
+  return { voteResult, deadPerson };
 }

--- a/packages/frontend/src/hooks/useVoteResult.ts
+++ b/packages/frontend/src/hooks/useVoteResult.ts
@@ -32,17 +32,14 @@ export default function useVoteResult(
           if (isPinoco) socket.emit('start_guessing');
           setGamePhase(GAME_PHASE.GUESSING);
         } else {
-          setRemainingPlayers((prev: number) => {
-            const updatedPlayers = prev - 1;
-            if (updatedPlayers <= 2) {
-              socket.emit('start_ending');
-              setGamePhase(GAME_PHASE.ENDING);
-            } else {
-              socket.emit('start_speaking');
-              setGamePhase(GAME_PHASE.SPEAKING);
-            }
-            return updatedPlayers;
-          });
+          setRemainingPlayers(remainingPlayers - 1);
+          if (remainingPlayers - 1 <= 2) {
+            socket.emit('start_ending');
+            setGamePhase(GAME_PHASE.ENDING);
+          } else {
+            socket.emit('start_speaking');
+            setGamePhase(GAME_PHASE.SPEAKING);
+          }
         }
       }, 5000);
     });
@@ -50,7 +47,7 @@ export default function useVoteResult(
     return () => {
       socket.off('receive_vote_result');
     };
-  }, [socket, setGamePhase, isPinoco, setRemainingPlayers]);
+  }, [socket, setGamePhase, isPinoco, remainingPlayers, setRemainingPlayers]);
 
   return { voteResult, deadPerson };
 }


### PR DESCRIPTION
## 개요

Resolves: #132 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 작업 내용

- 투표 결과를 렌더링하고, 경우에 따라 다음 페이즈(SPEAKING, GUESSING, ENDING)로 전환하는 로직을 구현했습니다.



## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
