### PR TITLE
[Chore] VITE 환경 변수 설정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         working-directory: packages/frontend
 
       - name: 빌드
+        env:
+          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
         run: yarn build
         working-directory: packages/frontend
 

--- a/packages/frontend/src/apis/instance.ts
+++ b/packages/frontend/src/apis/instance.ts
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000';
+
 export const instance = axios.create({
-  baseURL: 'http://localhost:3000',
+  baseURL: API_BASE_URL,
   withCredentials: true,
 });
 

--- a/packages/frontend/src/states/store/socketStore.ts
+++ b/packages/frontend/src/states/store/socketStore.ts
@@ -11,7 +11,7 @@ export const useSocketStore = create<ISocketStore>((set) => ({
   socket: null,
   connectSocket: (userId: string, password: string) => {
     return new Promise((resolve, reject) => {
-      const socket = io('http://localhost:3000', {
+      const socket = io(import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000', {
         query: { userId, password },
         withCredentials: true,
         transports: ['websocket', 'polling'],


### PR DESCRIPTION
## 개요

Resolves: #141 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 빌드 부분 혹은 패키지 매니저 수정


## 작업 내용

- 프론트엔드 socketStore와 API instance에서 URL 값을 .env에서 가져오도록 수정.

- .env 파일에 VITE_API_BASE_URL 추가

- .gitignore에 .env 파일 포함하여 환경 변수가 Git에 노출되지 않도록 설정

- GitHub Secrets를 통해 배포 환경에서 환경 변수 자동 적용

### GitHub Secrets에 환경 변수 추가 방법

1. GitHub 레포지토리의 Settings 탭으로 이동

2. Secrets and variables > Actions 섹션으로 이동

3. New repository secret 버튼을 클릭

4. Name에 환경 변수 이름을 입력

5. Value에 환경 변수 값을 입력

6. Add secret 버튼을 클릭하여 저장


## 스크린샷

![스크린샷 2024-11-21 오후 10 18 45](https://github.com/user-attachments/assets/906b2142-884c-4f6d-8d1d-a43bbfe465a2)


## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
