### PR TITLE
[Fix] start_speaker 관련 에러 해결

### DIFF
--- a/packages/backend/gameserver/src/game/types/game.types.ts
+++ b/packages/backend/gameserver/src/game/types/game.types.ts
@@ -15,6 +15,7 @@ export interface IGameState {
   votes: Record<string, string>;
   isGuessed?: boolean;
   guessingWord?: string;
+  spokenUsers: Set<string>;
 }
 
 export interface IGameInfo extends IGameState {

--- a/packages/backend/gameserver/src/gateway/gateway.gateway.ts
+++ b/packages/backend/gameserver/src/gateway/gateway.gateway.ts
@@ -259,18 +259,32 @@ export class GatewayGateway
     this.logger.logSocketEvent('receive', 'end_speaking', { userId, gsid });
 
     try {
-      await this.gatewayService.handleSpeakingEnd(gsid, userId);
+      const isAllSpoken = await this.gatewayService.handleSpeakingEnd(
+        gsid,
+        userId,
+      );
       const gameState = this.gameService.getGameState(gsid);
+      console.log('Game state after speaking end:', {
+        phase: gameState.phase,
+        isAllSpoken,
+        spokenUsers: Array.from(gameState.spokenUsers),
+        totalUsers: this.roomService.getRoom(gsid)?.userIds.size,
+      });
 
-      if (gameState.phase === 'VOTING') {
+      if (isAllSpoken) {
+        console.log('모든 사용자가 발언을 마쳤습니다. 투표를 시작합니다.');
         this.logger.logSocketEvent('send', 'start_vote', { gsid });
-        this.server.to(gsid).emit('start_vote');
+        // 룸의 모든 소켓에 직접 이벤트 전송
+        const sockets = await this.server.in(gsid).fetchSockets();
+        sockets.forEach((socket) => {
+          socket.emit('start_vote');
+        });
       } else {
         this.logger.logSocketEvent('send', 'start_speaking', {
           gsid,
           speakerId: gameState.currentSpeakerId,
+          spokenUsers: Array.from(gameState.spokenUsers),
         });
-        console.log('from start_speaking', gameState.currentSpeakerId);
         this.server.to(gsid).emit('start_speaking', {
           speakerId: gameState.currentSpeakerId,
         });

--- a/packages/backend/gameserver/src/gateway/gateway.service.ts
+++ b/packages/backend/gameserver/src/gateway/gateway.service.ts
@@ -92,7 +92,7 @@ export class GatewayService {
     };
   }
 
-  async handleSpeakingEnd(gsid: string, userId: string): Promise<void> {
+  async handleSpeakingEnd(gsid: string, userId: string): Promise<boolean> {
     const game = this.gameService.getGameState(gsid);
     if (!game) throw new Error('게임을 찾을 수 없습니다.');
 
@@ -100,7 +100,7 @@ export class GatewayService {
       throw new Error('현재 발언 차례가 아닙니다.');
     }
 
-    await this.gameService.endSpeaking(gsid);
+    return await this.gameService.endSpeaking(gsid);
   }
 
   async submitVote(

--- a/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
@@ -22,13 +22,10 @@ export default function MainDisplay() {
   const [countdown, setCountdown] = useState(3);
   const [currentWord, setCurrentWord] = useState('');
   const [selectedVote, setSelectedVote] = useState<string | null>(null);
-  const [isTimerActive, setIsTimerActive] = useState(true);
   const [isVoteSubmitted, setIsVoteSubmitted] = useState(false);
-
   const [remainingPlayers, setRemainingPlayers] = useState<number>(readyUsers.length);
 
   const { submitGuess } = useGuessing(isPinoco, setGamePhase);
-
   const { voteResult, deadPerson } = useVoteResult(remainingPlayers, setRemainingPlayers);
 
   useEffect(() => {
@@ -61,10 +58,6 @@ export default function MainDisplay() {
 
     votePinoco(selectedVote);
     setIsVoteSubmitted(true);
-
-    setTimeout(() => {
-      setIsTimerActive(false);
-    }, 1000);
   };
 
   const renderVotingUI = () => (
@@ -190,13 +183,13 @@ export default function MainDisplay() {
       </div>
       {gamePhase === GAME_PHASE.SPEAKING && (
         <div className="w-full mt-auto">
-          <Timer key={currentSpeaker} initialTime={30} onTimeEnd={() => endSpeaking(userId!)} />
+          <Timer key={currentSpeaker} initialTime={5} onTimeEnd={() => endSpeaking(userId!)} />
         </div>
       )}
 
       {gamePhase === GAME_PHASE.VOTING && (
         <div className="w-full mt-auto">
-          <Timer key="voting" initialTime={60} onTimeEnd={handleVote} />
+          <Timer key="voting" initialTime={10} onTimeEnd={handleVote} />
         </div>
       )}
     </div>

--- a/packages/frontend/src/pages/gamePage/index.tsx
+++ b/packages/frontend/src/pages/gamePage/index.tsx
@@ -2,8 +2,11 @@ import BackgroundImage from '@/components/layout/BackgroundImage';
 import LeftGameSection from '@/components/gamePage/leftSection/LeftGameSection';
 import RightGameSection from '@/components/gamePage/rightSection/RightGameSection';
 import Header from '@/components/layout/Header';
+import { useSocketStore } from '@/states/store/socketStore';
 
 export default function GamePage() {
+  const { socket } = useSocketStore();
+  console.log('gamePage', socket?.connected);
   return (
     <>
       <BackgroundImage gradientClass="bg-white/30" />


### PR DESCRIPTION
## 개요
Resolves: #146 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 버그 수정

## 작업 내용

서버에서 start_game_success시에 speakerId가 초기 발언자의 id인데, 
start_speaking에서 반환해주는 speakerId와 동일해서 문제가 발생했습니다. 즉 발언한 사람인데 그 사람에 대해서 또 발언기회를 주고 있는셈...
start_speaking이벤트의 경우 해당 방에 이미 발언한 사람을 제외한 사람중 한명의 id로 반환하게 하여 해결하였습니다.

타이머는 개발 편의상 5초로 설정해두었고 이후 로직이 성공적으로 완성되면 30초로 변경 예정입니다.

## 스크린샷

https://github.com/user-attachments/assets/0acf187a-5cd7-400c-9f77-f0bb321f4850


## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
