### PR TITLE
[Fix] 투표 이후에 참여자 투표했는지 상태 업데이트

### DIFF
--- a/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
@@ -16,17 +16,21 @@ export default function MainDisplay() {
   const { userId } = useAuthStore();
   const { isHost, isPinoco } = useRoomStore();
   const [gamePhase, setGamePhase] = useState<GamePhase>(GAME_PHASE.WAITING);
-  const { readyUsers, gameStartData, currentSpeaker, endSpeaking, votePinoco } =
-    useGameSocket(setGamePhase);
   const { endingResult } = useEnding(setGamePhase);
   const [countdown, setCountdown] = useState(3);
   const [currentWord, setCurrentWord] = useState('');
   const [selectedVote, setSelectedVote] = useState<string | null>(null);
   const [isVoteSubmitted, setIsVoteSubmitted] = useState(false);
+  const { readyUsers, gameStartData, currentSpeaker, endSpeaking, votePinoco } =
+    useGameSocket(setGamePhase);
   const [remainingPlayers, setRemainingPlayers] = useState<number>(readyUsers.length);
 
   const { submitGuess } = useGuessing(isPinoco, setGamePhase);
-  const { voteResult, deadPerson } = useVoteResult(remainingPlayers, setRemainingPlayers);
+  const { voteResult, deadPerson } = useVoteResult(
+    remainingPlayers,
+    setRemainingPlayers,
+    setIsVoteSubmitted,
+  );
 
   useEffect(() => {
     if (gameStartData) {

--- a/packages/frontend/src/hooks/useGameSocket.ts
+++ b/packages/frontend/src/hooks/useGameSocket.ts
@@ -33,7 +33,6 @@ export const useGameSocket = (onPhaseChange?: (phase: GamePhase) => void) => {
     if (!socket) return;
 
     const handleStartSpeaking = (data: ISpeakingStart) => {
-      console.log('백엔드에서 speakerId 오나 확인 [start_speaking]', data.speakerId);
       setCurrentSpeaker(data.speakerId);
       if (onPhaseChange) {
         onPhaseChange(GAME_PHASE.SPEAKING);
@@ -41,14 +40,12 @@ export const useGameSocket = (onPhaseChange?: (phase: GamePhase) => void) => {
     };
 
     const handleStartGame = (data: IGameStart) => {
-      console.log('초기 발언자 id [start_game_success]', data.speakerId);
       setGameStartData(data);
       setCurrentSpeaker(data.speakerId);
       setIsPinoco(data.isPinoco);
     };
 
     const handleStartVote = () => {
-      console.log('투표 시작 이벤트 수신!');
       if (onPhaseChange) {
         onPhaseChange(GAME_PHASE.VOTING);
       }

--- a/packages/frontend/src/hooks/useVoteResult.ts
+++ b/packages/frontend/src/hooks/useVoteResult.ts
@@ -9,6 +9,7 @@ interface IVoteResult {
 export default function useVoteResult(
   remainingPlayers: number,
   setRemainingPlayers: (value: number) => void,
+  onIsVotedChange?: (isVoted: boolean) => void,
 ) {
   const socket = useSocketStore((state) => state.socket);
   const [voteResult, setVoteResult] = useState<Record<string, number>>({});
@@ -18,6 +19,9 @@ export default function useVoteResult(
     if (!socket) return;
 
     socket.on('receive_vote_result', (data: IVoteResult) => {
+      if (onIsVotedChange) {
+        onIsVotedChange(false);
+      }
       setVoteResult(data.voteResult);
       setDeadPerson(data.deadPerson);
 
@@ -29,7 +33,7 @@ export default function useVoteResult(
     return () => {
       socket.off('receive_vote_result');
     };
-  }, [socket, remainingPlayers, setRemainingPlayers]);
+  }, [socket, remainingPlayers, setRemainingPlayers, onIsVotedChange]);
 
   return { voteResult, deadPerson };
 }


### PR DESCRIPTION
## 개요

Resolves: #148 

## PR 유형

- [x] 버그 수정

## 작업 내용

투표 이후에 투표 결과를 받는 과정에서 사용자가 다시 투표를 할 수 있게끔, 투표에 여부에 대한 상태를 false로 변경하였습니다

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
