### PR TITLE
[Fix] 한글 입력 시 마지막 글자가 중복 전송되는 문제 해결

### DIFF
--- a/packages/frontend/src/components/gamePage/rightSection/ChatSection.tsx
+++ b/packages/frontend/src/components/gamePage/rightSection/ChatSection.tsx
@@ -9,16 +9,27 @@ export default function ChatSection() {
   const { userId } = useAuthStore();
   const { chatHistory } = useChatStore();
   const { sendChatEntry } = useChatSocket(gsid!, userId!);
+
   const [chatInput, setChat] = useState('');
+  const [isComposing, setIsComposing] = useState(false);
 
   const handleSend = () => {
-    if (!chatInput.trim()) return;
+    if (!chatInput.trim() || isComposing) return;
     sendChatEntry(chatInput);
     setChat('');
   };
 
+  const handleCompositionStart = () => {
+    setIsComposing(true);
+  };
+
+  const handleCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>) => {
+    setIsComposing(false);
+    setChat(e.currentTarget.value);
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' && !isComposing) {
       handleSend();
     }
   };
@@ -37,6 +48,8 @@ export default function ChatSection() {
         placeholder="채팅을 입력해주세요..."
         value={chatInput}
         onChange={(e) => setChat(e.target.value)}
+        onCompositionStart={handleCompositionStart}
+        onCompositionEnd={handleCompositionEnd}
         onKeyDown={handleKeyDown}
       />
     </div>


### PR DESCRIPTION
## 개요

Resolves: #162 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 버그 수정

## 작업 내용

- 맥 환경에서 한글 입력 시 마지막 글자가 추가로 전송되는 문제는 **IME 입력**의 조합 상태와 관련이 있었습니다.

- IME는 `Input Method Editor`의 약자인디, 한글처럼 입력할 때 자음과 모음을 조합하여 글자를 완성하는 언어의 입력에서 사용됩니다.

- 즉, 이러한 한글 입력 방식에서 조합이 완료되지 않은 상태에서 `onKeyDown` 이벤트가 발생하는게 문제의 원인이었습니다.

- 해결을 위해 `ChatSection.tsx` 컴포넌트에 `isComposing`를 추가하여 한글 입력 조합 상태를 확인하도록 했습니다.

onCompositionStart → isComposing: true
onCompositionEnd → isComposing: false

- 조합 중에는 Enter 키를 무시하고, 조합이 끝난 이후에만 전송 가능하도록 했습니다.


## 스크린샷

![스크린샷 2024-11-25 오후 11 19 07](https://github.com/user-attachments/assets/475217ad-d430-44ae-9221-2fa755193845)


## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
