### PR TITLE
[Fix] 사용자가 브라우저 창을 끄거나, 초기 로그인시에 로컬 스토리지에 저장된 값을 없애도록 수정

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,10 +1,24 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from 'react-router-dom';
 import { router } from './routes/router';
+import { useEffect } from 'react';
 
 const queryClient = new QueryClient();
 
 function App() {
+  useEffect(() => {
+    const handleUnload = () => {
+      localStorage.removeItem('auth-storage');
+      localStorage.removeItem('room-storage');
+    };
+
+    window.addEventListener('beforeunload', handleUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleUnload);
+    };
+  }, []);
+
   return (
     <>
       <QueryClientProvider client={queryClient}>

--- a/packages/frontend/src/components/landingPage/GuestLoginButton.tsx
+++ b/packages/frontend/src/components/landingPage/GuestLoginButton.tsx
@@ -13,6 +13,9 @@ export default function GuestLoginButton() {
 
   async function handleClick() {
     try {
+      localStorage.removeItem('auth-storage');
+      localStorage.removeItem('room-storage');
+
       const { userId, password } = await postGuestLogin();
       await connectSocket(userId, password);
       await connectSignalingSocket(userId);


### PR DESCRIPTION
## 개요

Resolves: #164 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 작업 내용

사용자가 브라우저 창을 끄는 경우 최상위 컴포넌트에서 이를 감지하고 로컬 스토리지에 저장되어 있는 auth, room 관련 값들을 삭제해줍니다.
또, 로그인시에도 동일하게 삭제해주었습니다

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
