### PR TITLE
[Feat] 투표 결과 무효표 처리 & 탈락자 역할 공개 로직 추가

### DIFF
--- a/packages/frontend/src/components/gamePage/leftSection/GamePhases/VoteResult.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/GamePhases/VoteResult.tsx
@@ -1,23 +1,53 @@
 interface IVoteResultPhaseProps {
-  deadPerson: string;
+  deadPerson: string | null;
   voteResult: Record<string, number>;
+  isPinoco: boolean;
 }
 
-export default function VoteResult({ deadPerson, voteResult }: IVoteResultPhaseProps) {
+export default function VoteResult({ deadPerson, voteResult, isPinoco }: IVoteResultPhaseProps) {
+  const maxVotes = Math.max(...Object.values(voteResult));
+  const maxVotedUsers = Object.entries(voteResult)
+    .filter(([_, votes]) => votes === maxVotes)
+    .map(([userId]) => userId);
+  const totalVotes = Object.values(voteResult).reduce((sum, votes) => sum + votes, 0);
+
+  const isTie = maxVotedUsers.length > 1;
+  const isNoElimination = isTie || maxVotedUsers.includes('');
+
+  const getRoleText = (userId: string) => {
+    return userId === '' ? '' : isPinoco && userId === deadPerson ? '피노코' : '제페토';
+  };
+
   return (
     <div className="flex flex-col items-center justify-center w-full h-full space-y-4">
       <h2 className="text-2xl font-bold text-white-default">투표 결과</h2>
-      {deadPerson === '' ? (
-        <p className="text-xl text-white-default">동점입니다. 아무도 제거되지 않았습니다.</p>
+      {deadPerson ? (
+        <>
+          <p className="text-xl text-white-default">
+            {deadPerson}님이 제거되었습니다. {deadPerson}님은 {getRoleText(deadPerson)}였습니다 !
+          </p>
+        </>
+      ) : isNoElimination ? (
+        <p className="text-xl text-white-default">
+          {isTie
+            ? '동점입니다. 아무도 제거되지 않았습니다.'
+            : '무효표가 가장 많아 아무도 제거되지 않았습니다.'}
+        </p>
       ) : (
-        <p className="text-xl text-white-default">{deadPerson}님이 제거되었습니다.</p>
+        <p className="text-xl text-white-default">에러가 발생했습니다.</p>
       )}
       <ul className="mt-4 space-y-2">
-        {Object.entries(voteResult).map(([userId, votes]) => (
-          <li key={userId} className="text-lg text-white-default">
-            {userId}: {votes}표
-          </li>
-        ))}
+        {Object.entries(voteResult).map(([userId, votes]) =>
+          userId === '' ? (
+            <li key="invalid" className="text-lg text-white-default">
+              무효표: {votes}표
+            </li>
+          ) : (
+            <li key={userId} className="text-lg text-white-default">
+              {userId}: {votes}표
+            </li>
+          ),
+        )}
       </ul>
     </div>
   );

--- a/packages/frontend/src/components/gamePage/leftSection/GamePhases/VoteResult.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/GamePhases/VoteResult.tsx
@@ -18,6 +18,16 @@ export default function VoteResult({ deadPerson, voteResult, isPinoco }: IVoteRe
     return userId === '' ? '' : isPinoco && userId === deadPerson ? '피노코' : '제페토';
   };
 
+  const renderVoteResults = () => (
+    <ul className="mt-4 space-y-2">
+      {Object.entries(voteResult).map(([userId, votes]) => (
+        <li key={userId === '' ? 'invalid' : userId} className="text-lg text-white-default">
+          {userId === '' ? `무효표: ${votes}표` : `${userId}: ${votes}표`}
+        </li>
+      ))}
+    </ul>
+  );
+
   if (deadPerson) {
     return (
       <div className="flex flex-col items-center justify-center w-full h-full space-y-4">
@@ -25,19 +35,7 @@ export default function VoteResult({ deadPerson, voteResult, isPinoco }: IVoteRe
         <p className="text-xl text-white-default">
           {deadPerson}님이 제거되었습니다. {deadPerson}님은 {getRoleText(deadPerson)}였습니다!
         </p>
-        <ul className="mt-4 space-y-2">
-          {Object.entries(voteResult).map(([userId, votes]) =>
-            userId === '' ? (
-              <li key="invalid" className="text-lg text-white-default">
-                무효표: {votes}표
-              </li>
-            ) : (
-              <li key={userId} className="text-lg text-white-default">
-                {userId}: {votes}표
-              </li>
-            ),
-          )}
-        </ul>
+        {renderVoteResults()}
       </div>
     );
   }
@@ -51,19 +49,7 @@ export default function VoteResult({ deadPerson, voteResult, isPinoco }: IVoteRe
       <div className="flex flex-col items-center justify-center w-full h-full space-y-4">
         <h2 className="text-2xl font-bold text-white-default">투표 결과</h2>
         <p className="text-xl text-white-default">{noEliminationMessage}</p>
-        <ul className="mt-4 space-y-2">
-          {Object.entries(voteResult).map(([userId, votes]) =>
-            userId === '' ? (
-              <li key="invalid" className="text-lg text-white-default">
-                무효표: {votes}표
-              </li>
-            ) : (
-              <li key={userId} className="text-lg text-white-default">
-                {userId}: {votes}표
-              </li>
-            ),
-          )}
-        </ul>
+        {renderVoteResults()}
       </div>
     );
   }
@@ -72,19 +58,7 @@ export default function VoteResult({ deadPerson, voteResult, isPinoco }: IVoteRe
     <div className="flex flex-col items-center justify-center w-full h-full space-y-4">
       <h2 className="text-2xl font-bold text-white-default">투표 결과</h2>
       <p className="text-xl text-white-default">에러가 발생했습니다.</p>
-      <ul className="mt-4 space-y-2">
-        {Object.entries(voteResult).map(([userId, votes]) =>
-          userId === '' ? (
-            <li key="invalid" className="text-lg text-white-default">
-              무효표: {votes}표
-            </li>
-          ) : (
-            <li key={userId} className="text-lg text-white-default">
-              {userId}: {votes}표
-            </li>
-          ),
-        )}
-      </ul>
+      {renderVoteResults()}
     </div>
   );
 }

--- a/packages/frontend/src/components/gamePage/leftSection/GamePhases/VoteResult.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/GamePhases/VoteResult.tsx
@@ -18,24 +18,60 @@ export default function VoteResult({ deadPerson, voteResult, isPinoco }: IVoteRe
     return userId === '' ? '' : isPinoco && userId === deadPerson ? '피노코' : '제페토';
   };
 
+  if (deadPerson) {
+    return (
+      <div className="flex flex-col items-center justify-center w-full h-full space-y-4">
+        <h2 className="text-2xl font-bold text-white-default">투표 결과</h2>
+        <p className="text-xl text-white-default">
+          {deadPerson}님이 제거되었습니다. {deadPerson}님은 {getRoleText(deadPerson)}였습니다!
+        </p>
+        <ul className="mt-4 space-y-2">
+          {Object.entries(voteResult).map(([userId, votes]) =>
+            userId === '' ? (
+              <li key="invalid" className="text-lg text-white-default">
+                무효표: {votes}표
+              </li>
+            ) : (
+              <li key={userId} className="text-lg text-white-default">
+                {userId}: {votes}표
+              </li>
+            ),
+          )}
+        </ul>
+      </div>
+    );
+  }
+
+  if (isNoElimination) {
+    const noEliminationMessage = isTie
+      ? '동점입니다. 아무도 제거되지 않았습니다.'
+      : '무효표가 가장 많아 아무도 제거되지 않았습니다.';
+
+    return (
+      <div className="flex flex-col items-center justify-center w-full h-full space-y-4">
+        <h2 className="text-2xl font-bold text-white-default">투표 결과</h2>
+        <p className="text-xl text-white-default">{noEliminationMessage}</p>
+        <ul className="mt-4 space-y-2">
+          {Object.entries(voteResult).map(([userId, votes]) =>
+            userId === '' ? (
+              <li key="invalid" className="text-lg text-white-default">
+                무효표: {votes}표
+              </li>
+            ) : (
+              <li key={userId} className="text-lg text-white-default">
+                {userId}: {votes}표
+              </li>
+            ),
+          )}
+        </ul>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col items-center justify-center w-full h-full space-y-4">
       <h2 className="text-2xl font-bold text-white-default">투표 결과</h2>
-      {deadPerson ? (
-        <>
-          <p className="text-xl text-white-default">
-            {deadPerson}님이 제거되었습니다. {deadPerson}님은 {getRoleText(deadPerson)}였습니다 !
-          </p>
-        </>
-      ) : isNoElimination ? (
-        <p className="text-xl text-white-default">
-          {isTie
-            ? '동점입니다. 아무도 제거되지 않았습니다.'
-            : '무효표가 가장 많아 아무도 제거되지 않았습니다.'}
-        </p>
-      ) : (
-        <p className="text-xl text-white-default">에러가 발생했습니다.</p>
-      )}
+      <p className="text-xl text-white-default">에러가 발생했습니다.</p>
       <ul className="mt-4 space-y-2">
         {Object.entries(voteResult).map(([userId, votes]) =>
           userId === '' ? (

--- a/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
@@ -95,9 +95,8 @@ export default function MainDisplay() {
         )}
 
         {gamePhase === GAME_PHASE.VOTING_RESULT && (
-          <VoteResult deadPerson={deadPerson ?? ''} voteResult={voteResult} />
+          <VoteResult deadPerson={deadPerson ?? ''} voteResult={voteResult} isPinoco={isPinoco} />
         )}
-
         {gamePhase === GAME_PHASE.GUESSING && (
           <div className="flex flex-col items-center justify-center h-full">
             {isPinoco ? (


### PR DESCRIPTION
## 개요

Resolves: #182 

## 작업 내용

### 무효표 처리

- `voteResult`에서 `userId`가 빈 문자열 ("")인 경우를 무효표로 정의했습니다.

- 무효표가 최다 득표와 같은 경우, 탈락자가 없음을 명확히 표시했습니다.

### 동점 상황 처리

- 최다 득표자가 여러 명일 경우(1:1, 2:2 등), "동점입니다. 아무도 제거되지 않았습니다."라는 메시지를 표시하도록 수정했습니다.

### 탈락자 역할 표시

- 탈락자가 존재할 경우, 해당 유저가 피노코였는지 제페토였는지를 추가로 표시했습니다.

- 이를 위해 `isPinoco` 상태와 `deadPerson` 정보를 활용하여 탈락자의 역할을 공지하도록 했습니다.

## 스크린샷

![스크린샷 2024-11-28 오전 12 22 40](https://github.com/user-attachments/assets/eaf398ff-49bc-4d9b-ad97-b362706ed575)

- 무효표가 가장 많은 경우 멘트 추가

![스크린샷 2024-11-28 오전 12 21 52](https://github.com/user-attachments/assets/edef02c8-4f70-4266-8754-c1c867cc7a38)

- 무효표와 최다 득표자의 표가 같은데, 최다 득표자가 여러명일 때에는 (1:1:1 or 2:2:2) 동점 공지

![스크린샷 2024-11-28 오전 12 33 10](https://github.com/user-attachments/assets/f919a6eb-6899-4f9d-b930-970fe3b2dd43)

- 투표 결과에 역할 공지 추가


## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
