### PR TITLE
[Feat] 발언 조기 종료 구현

### DIFF
--- a/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
@@ -18,6 +18,7 @@ import EndingResult from './GamePhases/EndingResult';
 import { usePeerConnectionStore } from '@/states/store/peerConnectionStore';
 import VideoStream from '@/components/gamePage/stream/VideoStream';
 import { useLocalStreamStore } from '@/states/store/localStreamStore';
+import { useSpeakingControl } from '@/hooks/useSpeakingControl';
 
 export default function MainDisplay() {
   const { userId } = useAuthStore();
@@ -28,6 +29,8 @@ export default function MainDisplay() {
   const [selectedVote, setSelectedVote] = useState<string | null>(null);
   const [isVoteSubmitted, setIsVoteSubmitted] = useState(false);
   const { gameStartData, currentSpeaker, endSpeaking, votePinoco } = useGameSocket(setGamePhase);
+  const { endSpeakingEarly } = useSpeakingControl(currentSpeaker, userId);
+
   const { endingResult } = useEnding(setGamePhase);
   const { submitGuess } = useGuessing(isPinoco, setGamePhase);
   const { voteResult, deadPerson, isDeadPersonPinoco } = useVoteResult(
@@ -103,6 +106,14 @@ export default function MainDisplay() {
             <div className="absolute p-2 text-lg rounded-lg top-16 left-4 text-white-default bg-slate-950">
               📢 {currentSpeaker}
             </div>
+            {currentSpeaker === userId && (
+              <button
+                className="mt-4 px-6 py-2 bg-green-default text-white-default rounded-lg hover:bg-green-200 hover:text-black self-end ml-auto"
+                onClick={endSpeakingEarly}
+              >
+                발언 종료
+              </button>
+            )}
           </div>
         )}
 

--- a/packages/frontend/src/hooks/useSpeakingControl.ts
+++ b/packages/frontend/src/hooks/useSpeakingControl.ts
@@ -8,18 +8,5 @@ export const useSpeakingControl = (currentSpeaker: string | null, userId: string
     if (!socket || currentSpeaker !== userId) return;
     socket.emit('end_speaking');
   };
-
-  useEffect(() => {
-    if (!socket) return;
-
-    socket.on('speaking_ended', () => {
-      console.log('발언 종료 처리됨');
-    });
-
-    return () => {
-      socket.off('speaking_ended');
-    };
-  }, [socket]);
-
   return { endSpeakingEarly };
 };

--- a/packages/frontend/src/hooks/useSpeakingControl.ts
+++ b/packages/frontend/src/hooks/useSpeakingControl.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useSocketStore } from '@/states/store/socketStore';
+
+export const useSpeakingControl = (currentSpeaker: string | null, userId: string | null) => {
+  const socket = useSocketStore((state) => state.socket);
+
+  const endSpeakingEarly = () => {
+    if (!socket || currentSpeaker !== userId) return;
+    socket.emit('end_speaking');
+  };
+
+  useEffect(() => {
+    if (!socket) return;
+
+    socket.on('speaking_ended', () => {
+      console.log('발언 종료 처리됨');
+    });
+
+    return () => {
+      socket.off('speaking_ended');
+    };
+  }, [socket]);
+
+  return { endSpeakingEarly };
+};


### PR DESCRIPTION
## 개요

Resolves: #202 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 작업 내용

- 발언 시간이 남았을 때에 이를 조기 종료하고 다음 차례 혹은 투표로 넘어갈 수 있도록 하는 `useSpeakingControl` 훅을 구현하고, 이를 사용하는 버튼을 `MainDisplay.tsx`에 추가했습니다.

## 스크린샷


https://github.com/user-attachments/assets/dc20e496-9851-4634-9b35-51d370c14cb3

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
