### PR TITLE
[Feat] 게임 대기 중 준비 상태를 플레이어 모두가 공유하는 기능 추가

### DIFF
--- a/packages/frontend/src/components/gamePage/leftSection/GameButtons/ReadyButton.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/GameButtons/ReadyButton.tsx
@@ -14,7 +14,7 @@ export default function ReadyButton() {
 
   return (
     <Button
-      buttonText={isReady ? '준비완료' : '준비하기'}
+      buttonText={isReady ? '준비완료✅' : '준비하기🤔'}
       className={`max-w-xs text-xl transition-all text-white-default ${
         isReady ? 'bg-green-default' : 'bg-black opacity-90'
       }`}

--- a/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/MainDisplay.tsx
@@ -18,6 +18,7 @@ import EndingResult from './GamePhases/EndingResult';
 import { usePeerConnectionStore } from '@/states/store/peerConnectionStore';
 import VideoStream from '@/components/gamePage/stream/VideoStream';
 import { useLocalStreamStore } from '@/states/store/localStreamStore';
+import { useSpeakingControl } from '@/hooks/useSpeakingControl';
 
 export default function MainDisplay() {
   const { userId } = useAuthStore();
@@ -28,6 +29,8 @@ export default function MainDisplay() {
   const [selectedVote, setSelectedVote] = useState<string | null>(null);
   const [isVoteSubmitted, setIsVoteSubmitted] = useState(false);
   const { gameStartData, currentSpeaker, endSpeaking, votePinoco } = useGameSocket(setGamePhase);
+  const { endSpeakingEarly } = useSpeakingControl(currentSpeaker, userId);
+
   const { endingResult } = useEnding(setGamePhase);
   const { submitGuess } = useGuessing(isPinoco, setGamePhase);
   const { voteResult, deadPerson, isDeadPersonPinoco } = useVoteResult(
@@ -103,6 +106,14 @@ export default function MainDisplay() {
             <div className="absolute p-2 text-lg rounded-lg top-16 left-4 text-white-default bg-slate-950">
               📢 {currentSpeaker}
             </div>
+            {currentSpeaker === userId && (
+              <button
+                className="mt-4 px-6 py-2 bg-green-default text-white-default rounded-lg hover:bg-green-200 hover:text-black self-end ml-auto"
+                onClick={endSpeakingEarly}
+              >
+                발언 종료
+              </button>
+            )}
           </div>
         )}
 

--- a/packages/frontend/src/components/gamePage/leftSection/VideoFeed.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/VideoFeed.tsx
@@ -3,24 +3,50 @@ import VideoStream from '@/components/gamePage/stream/VideoStream';
 import { useAuthStore } from '@/states/store/authStore';
 import { useLocalStreamStore } from '@/states/store/localStreamStore';
 import { usePeerConnectionStore } from '@/states/store/peerConnectionStore';
+import { useReadyStatus } from '@/hooks/useReadyStatus';
 
 export default function VideoFeed() {
   const localStream = useLocalStreamStore((state) => state.localStream);
   const remoteStreams = usePeerConnectionStore((state) => state.remoteStreams);
   const { userId } = useAuthStore();
   const feedHeight = 'h-[180px]';
+  const { isUserReady } = useReadyStatus();
 
   return (
     <>
-      <VideoStream stream={localStream} userName={userId} isLocal={true} height={feedHeight} />
-      {Array.from(remoteStreams).map(([userId, stream]) => (
-        <VideoStream
-          key={userId}
-          stream={stream}
-          userName={userId}
-          isLocal={false}
-          height={feedHeight}
-        />
+      <div
+        className={`relative ${
+          isUserReady(userId || '') ? 'border-4 border-white' : ''
+        } rounded-lg`}
+      >
+        <VideoStream stream={localStream} userName={userId} isLocal={true} height={feedHeight} />
+        {isUserReady(userId || '') && (
+          <div className="absolute bottom-2 right-2">
+            <span className="px-2 py-1 text-orange-500 font-bold bg-white rounded-full">READY</span>
+          </div>
+        )}
+      </div>
+      {Array.from(remoteStreams).map(([remoteUserId, stream]) => (
+        <div
+          key={remoteUserId}
+          className={`relative ${
+            isUserReady(remoteUserId) ? 'border-4 border-white' : ''
+          } rounded-lg`}
+        >
+          <VideoStream
+            stream={stream}
+            userName={remoteUserId}
+            isLocal={false}
+            height={feedHeight}
+          />
+          {isUserReady(remoteUserId) && (
+            <div className="absolute bottom-2 right-2 animate-spin-slow">
+              <span className="px-2 py-1 text-orange-500 font-bold bg-white rounded-full">
+                READY
+              </span>
+            </div>
+          )}
+        </div>
       ))}
       {[...Array(Math.max(0, 5 - remoteStreams.size))].map((_, idx) => (
         <VideoStream

--- a/packages/frontend/src/hooks/useReadyStatus.ts
+++ b/packages/frontend/src/hooks/useReadyStatus.ts
@@ -1,0 +1,9 @@
+import { useGameSocket } from '@/hooks/useGameSocket';
+
+export const useReadyStatus = () => {
+  const { readyUsers } = useGameSocket();
+
+  const isUserReady = (userId: string) => readyUsers.includes(userId);
+
+  return { isUserReady };
+};

--- a/packages/frontend/src/hooks/useSpeakingControl.ts
+++ b/packages/frontend/src/hooks/useSpeakingControl.ts
@@ -8,18 +8,5 @@ export const useSpeakingControl = (currentSpeaker: string | null, userId: string
     if (!socket || currentSpeaker !== userId) return;
     socket.emit('end_speaking');
   };
-
-  useEffect(() => {
-    if (!socket) return;
-
-    socket.on('speaking_ended', () => {
-      console.log('발언 종료 처리됨');
-    });
-
-    return () => {
-      socket.off('speaking_ended');
-    };
-  }, [socket]);
-
   return { endSpeakingEarly };
 };

--- a/packages/frontend/src/hooks/useSpeakingControl.ts
+++ b/packages/frontend/src/hooks/useSpeakingControl.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useSocketStore } from '@/states/store/socketStore';
+
+export const useSpeakingControl = (currentSpeaker: string | null, userId: string | null) => {
+  const socket = useSocketStore((state) => state.socket);
+
+  const endSpeakingEarly = () => {
+    if (!socket || currentSpeaker !== userId) return;
+    socket.emit('end_speaking');
+  };
+
+  useEffect(() => {
+    if (!socket) return;
+
+    socket.on('speaking_ended', () => {
+      console.log('발언 종료 처리됨');
+    });
+
+    return () => {
+      socket.off('speaking_ended');
+    };
+  }, [socket]);
+
+  return { endSpeakingEarly };
+};


### PR DESCRIPTION
## 개요

Resolves: #205 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가


## 작업 내용

- 준비 완료된 사용자 목록을 불러오는 `useReadyStatus` 훅을 추가하고, 이를 바탕으로 준비완료한 사용자의 비디오 피드에 'READY' 표시를 나타내도록 하는 기능을 구현했습니다.

- 추가로 준비 버튼의 텍스트에 이모지를 추가하여 직관성을 높이고자 했습니다.


## 스크린샷

![스크린샷 2024-12-01 오후 11 01 00](https://github.com/user-attachments/assets/c69dad8b-6841-4fa5-9bf7-b9205d49a941)


## 공유사항 to 리뷰어

- 나중에 접속한 플레이어의 경우, 누군가 준비 여부를 변경하기 이전에는 방에 접속하기 전에 일어난 준비완료가 나타나지 않는 상태입니다.

- 접속 시에 곧바로 준비 여부를 띄워주기 위해 백엔드와의 작업이 필요할 것 같습니다.

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
