### PR TITLE
[Feat] 준비 로직 리팩토링

### DIFF
--- a/packages/frontend/src/components/gamePage/leftSection/VideoFeed.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/VideoFeed.tsx
@@ -1,16 +1,18 @@
-import { useRef, useEffect } from 'react';
+import { useEffect } from 'react';
 import VideoStream from '@/components/gamePage/stream/VideoStream';
 import { useAuthStore } from '@/store/authStore';
 import { useLocalStreamStore } from '@/store/localStreamStore';
 import { usePeerConnectionStore } from '@/store/peerConnectionStore';
 import { useReadyStatus } from '@/hooks/useReadyStatus';
+import { useRoomStore } from '@/store/roomStore';
 
 export default function VideoFeed() {
   const localStream = useLocalStreamStore((state) => state.localStream);
   const remoteStreams = usePeerConnectionStore((state) => state.remoteStreams);
   const { userId } = useAuthStore();
   const feedHeight = 'h-[180px]';
-  const { isUserReady } = useReadyStatus();
+  const readyUsers = useRoomStore((state) => state.readyUsers);
+  const isUserReady = (userId: string) => readyUsers.includes(userId);
 
   return (
     <>
@@ -40,7 +42,7 @@ export default function VideoFeed() {
             height={feedHeight}
           />
           {isUserReady(remoteUserId) && (
-            <div className="absolute bottom-2 right-2 animate-spin-slow">
+            <div className="absolute bottom-2 right-2">
               <span className="px-2 py-1 text-orange-500 font-bold bg-white rounded-full">
                 READY
               </span>

--- a/packages/frontend/src/components/gamePage/leftSection/VideoFeed.tsx
+++ b/packages/frontend/src/components/gamePage/leftSection/VideoFeed.tsx
@@ -3,7 +3,6 @@ import VideoStream from '@/components/gamePage/stream/VideoStream';
 import { useAuthStore } from '@/store/authStore';
 import { useLocalStreamStore } from '@/store/localStreamStore';
 import { usePeerConnectionStore } from '@/store/peerConnectionStore';
-import { useReadyStatus } from '@/hooks/useReadyStatus';
 import { useRoomStore } from '@/store/roomStore';
 
 export default function VideoFeed() {

--- a/packages/frontend/src/components/lobbyPage/GameEntryModal.tsx
+++ b/packages/frontend/src/components/lobbyPage/GameEntryModal.tsx
@@ -1,5 +1,5 @@
 import ReactDOM from 'react-dom';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Tooltip } from 'react-tooltip';
 
 interface IGameEntryModalProps {
@@ -20,12 +20,17 @@ export default function GameEntryModal({
   const [gameCode, setGameCode] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const [showTooltip, setShowTooltip] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     if (!localStorage.getItem('modalTooltipShown')) {
       setShowTooltip(true);
       localStorage.setItem('modalTooltipShown', 'true');
     }
+  }, []);
+
+  useEffect(() => {
+    inputRef.current?.focus();
   }, []);
 
   const handleConfirm = () => {
@@ -59,6 +64,7 @@ export default function GameEntryModal({
         {textForm && (
           <input
             type="text"
+            ref={inputRef}
             placeholder={textForm}
             value={gameCode}
             onChange={(e) => setGameCode(e.target.value)}

--- a/packages/frontend/src/hooks/useGameSocket.ts
+++ b/packages/frontend/src/hooks/useGameSocket.ts
@@ -46,6 +46,7 @@ export const useGameSocket = (onPhaseChange?: (phase: GamePhase) => void) => {
       setGameStartData(data);
       setCurrentSpeaker(data.speakerId);
       setIsPinoco(data.isPinoco);
+      setReadyUsers([]);
     };
 
     const handleStartVote = () => {

--- a/packages/frontend/src/hooks/useGameSocket.ts
+++ b/packages/frontend/src/hooks/useGameSocket.ts
@@ -25,14 +25,17 @@ interface ISpeakingStart {
 
 export const useGameSocket = (onPhaseChange?: (phase: GamePhase) => void) => {
   const socket = useSocketStore((state) => state.socket);
-  const { setIsPinoco, setAllUsers } = useRoomStore();
-  const [readyUsers, setReadyUsers] = useState<string[]>([]);
+  const { setIsPinoco, setAllUsers, setReadyUsers } = useRoomStore();
   const [error, setError] = useState<string | null>(null);
   const [gameStartData, setGameStartData] = useState<IGameStart | null>(null);
   const [currentSpeaker, setCurrentSpeaker] = useState<string | null>(null);
 
   useEffect(() => {
     if (!socket) return;
+
+    const handleUpdateReady = (data: IReadyUsers) => {
+      setReadyUsers(data.readyUsers);
+    };
 
     const handleStartSpeaking = (data: ISpeakingStart) => {
       setCurrentSpeaker(data.speakerId);
@@ -55,27 +58,23 @@ export const useGameSocket = (onPhaseChange?: (phase: GamePhase) => void) => {
       }
     };
 
-    socket.on('update_ready', (data: IReadyUsers) => {
-      setReadyUsers(data.readyUsers);
-    });
-
+    socket.on('update_ready', handleUpdateReady);
     socket.on('error', (data: IGameErrorMessage) => {
       setError(data.errorMessage);
       setTimeout(() => setError(null), 3000);
     });
-
     socket.on('start_game_success', handleStartGame);
     socket.on('start_speaking', handleStartSpeaking);
     socket.on('start_vote', handleStartVote);
 
     return () => {
-      socket.off('update_ready');
+      socket.off('update_ready', handleUpdateReady);
       socket.off('error');
       socket.off('start_game_success', handleStartGame);
       socket.off('start_speaking', handleStartSpeaking);
       socket.off('start_vote', handleStartVote);
     };
-  }, [socket, setIsPinoco, onPhaseChange, setCurrentSpeaker, setAllUsers]);
+  }, [socket, setIsPinoco, onPhaseChange, setCurrentSpeaker, setAllUsers, setReadyUsers]);
 
   const sendReady = (isReady: boolean) => {
     if (!socket) return;
@@ -101,7 +100,6 @@ export const useGameSocket = (onPhaseChange?: (phase: GamePhase) => void) => {
   };
 
   return {
-    readyUsers,
     sendReady,
     startGame,
     error,

--- a/packages/frontend/src/hooks/useReadyStatus.ts
+++ b/packages/frontend/src/hooks/useReadyStatus.ts
@@ -1,9 +1,0 @@
-import { useGameSocket } from '@/hooks/useGameSocket';
-
-export const useReadyStatus = () => {
-  const { readyUsers } = useGameSocket();
-
-  const isUserReady = (userId: string) => readyUsers.includes(userId);
-
-  return { isUserReady };
-};

--- a/packages/frontend/src/store/roomStore.ts
+++ b/packages/frontend/src/store/roomStore.ts
@@ -1,16 +1,21 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+
 interface IRoomState {
   isHost: boolean;
   gsid: string | null;
   isPinoco: boolean;
   allUsers: Set<string>;
+  readyUsers: string[];
   setRoomData: (gsid: string | null, isHost: boolean, isPinoco: boolean) => void;
   setIsPinoco: (isPinoco: boolean) => void;
   setAllUsers: (allUsers: string[]) => void;
   addUser: (userId: string) => void;
   removeUser: (userId: string) => void;
   setIsHost: (isHost: boolean) => void;
+  setReadyUsers: (readyUsers: string[]) => void;
+  addReadyUser: (userId: string) => void;
+  removeReadyUser: (userId: string) => void;
 }
 export const useRoomStore = create<IRoomState>()(
   persist(
@@ -19,6 +24,8 @@ export const useRoomStore = create<IRoomState>()(
       gsid: null,
       isPinoco: false,
       allUsers: new Set(),
+      readyUsers: [],
+
       setRoomData: (gsid, isHost, isPinoco) => set({ gsid, isHost, isPinoco }),
       setIsPinoco: (isPinoco) => set({ isPinoco }),
       setAllUsers: (allUsers) => set({ allUsers: new Set(allUsers) }),
@@ -31,6 +38,16 @@ export const useRoomStore = create<IRoomState>()(
           allUsers: new Set([...state.allUsers].filter((id) => id !== userId)),
         })),
       setIsHost: (isHost) => set({ isHost }),
+
+      setReadyUsers: (readyUsers) => set({ readyUsers }),
+      addReadyUser: (userId) =>
+        set((state) => ({
+          readyUsers: [...state.readyUsers, userId],
+        })),
+      removeReadyUser: (userId) =>
+        set((state) => ({
+          readyUsers: state.readyUsers.filter((id) => id !== userId),
+        })),
     }),
     { name: 'room-storage' },
   ),


### PR DESCRIPTION
## 개요

Resolves: #214 


## PR 유형

어떤 변경 사항이 있나요?

- [x] 버그 수정
- [x] 파일 혹은 폴더 삭제

## 작업 내용

소켓 이벤트 핸들러와 전역 상태 관리를 개선하여 게임 반복 시 준비 상태의 정확한 반영과 첫 접속 시 기존 준비 상태 표시 기능을 구현했습니다.

### 1. 소켓 이벤트 핸들러 동일 참조 보장을 통해 준비 상태 정상 반영


```ts
// 기존 코드

useEffect(() => {
  const handleUpdateReady = (data: IReadyUsers) => {
    setReadyUsers(data.readyUsers);
  };

  socket.on('update_ready', handleUpdateReady);

  return () => {
    socket.off('update_ready');
  };
}, [socket]);
```

- 기존 코드에서 소켓 이벤트 핸들러(`handleUpdateReady`, `handleStartGame` 등)가 `useEffect` 내부에서 새로 정의되어있었는데, 이로 인해  `socket.on`으로 동일 이벤트 핸들러가 중복 등록되는 문제가 발생했습니다.

- 이렇게 중복 등록된 이벤트 핸들러들은 `socket.off` 작업이 제대로 이루어지지 않았습니다. 

- 이는 `socket.off('update_ready')` 호출 시, 등록된 핸들러와 참조가 일치하지 않아 이벤트가 제대로 해제되지 않았던 것이 원인이었습니다. 이것이 그동안 발생했던 메모리 누수의 주된 원인으로 추정됩니다.

```ts
// 개선 코드

useEffect(() => {
  const handleUpdateReady = (data: IReadyUsers) => {
    setReadyUsers(data.readyUsers);
  };

  socket.on('update_ready', handleUpdateReady);

  return () => {
    socket.off('update_ready', handleUpdateReady);
  };
}, [socket, setReadyUsers]);

```

- `socket.off` 에서 정확히 같은 참조를 사용할 수 있도록 `socket.off('update_ready', handleUpdateReady)`를 사용했습니다.

- 이제 게임이 반복되어도 소켓 이벤트 핸들러가 정확히 등록/해제되도록 보장하였으며, 이를 통해 사용자들의 준비 상태가 `VideoFeed`에 올바르게 표시됩니다.

### 2. 준비 상태를 전역 관리로 전환하여 첫 접속 시 준비 상태 표시

- 기존에 `useState`로 관리되던 `readyUsers`를 `roomStore` 전역 상태로 전환하여, 준비 상태 데이터를 다른 컴포넌트에서도 직접 참조할 수 있도록 수정했습니다.

-  `join_room_success`에서 수신한 준비 상태 데이터를 전역 상태에 저장하고, 이를 기반으로 이전에 입장한 사용자들의 준비 상태가 UI에 표시됩니다.

## 스크린샷


https://github.com/user-attachments/assets/53e16c50-6c4b-4ba0-afe5-1a31be2f7229


## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
